### PR TITLE
Merge main to dev

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,24 @@
 			<version>1.18.32</version>
 			<optional>true</optional>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-validation</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-jpa</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.mariadb.jdbc</groupId>
+			<artifactId>mariadb-java-client</artifactId>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.sendgrid</groupId>
+			<artifactId>sendgrid-java</artifactId>
+			<version>4.9.3</version>
+		</dependency>
 	</dependencies>
 	<dependencyManagement>
 		<dependencies>

--- a/src/main/java/com/infragest/infra_notifications_service/entity/BaseEntity.java
+++ b/src/main/java/com/infragest/infra_notifications_service/entity/BaseEntity.java
@@ -1,0 +1,70 @@
+package com.infragest.infra_notifications_service.entity;
+
+
+import jakarta.persistence.*;
+import lombok.Data;
+import org.hibernate.annotations.GenericGenerator;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+/**
+ * Superclase mapeada para entidades JPA con campos comunes.
+ * Contiene id (UUID), timestamps y versión para control optimista.
+ *
+ * @author bunnystring
+ * @since 2025-11-19
+ */
+@Data
+@MappedSuperclass
+public class BaseEntity {
+
+    /**
+     * Identificador único (UUID) generado por Hibernate.
+     */
+    @Id
+    @GeneratedValue(generator = "UUID")
+    @GenericGenerator(name = "UUID", strategy = "org.hibernate.id.UUIDGenerator")
+    @Column(name = "id", updatable = false, nullable = false)
+    private UUID id;
+
+    /**
+     * Fecha y hora de creación.
+     */
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    /**
+     * Fecha y hora de la última actualización.
+     */
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    /**
+     * Versión para control de concurrencia optimista.
+     */
+    @Version
+    @Column(name = "version")
+    private Long version;
+
+    /**
+     * Callback antes de persistir: asegura createdAt.
+     */
+    @PrePersist
+    public void prePersist() {
+        if (createdAt == null) createdAt = LocalDateTime.now();
+    }
+
+    /**
+     * Callback antes de actualizar: actualiza updatedAt.
+     */
+    @PreUpdate
+    public void preUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
+
+}

--- a/src/main/java/com/infragest/infra_notifications_service/entity/Notification.java
+++ b/src/main/java/com/infragest/infra_notifications_service/entity/Notification.java
@@ -1,0 +1,49 @@
+package com.infragest.infra_notifications_service.entity;
+
+import com.infragest.infra_notifications_service.enums.NotificationStatus;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.UUID;
+
+@Entity
+@Table(name = "notifications", indexes = {
+        @Index(name = "idx_notification_order_id", columnList = "order_id"),
+        @Index(name = "idx_notification_status", columnList = "status"),
+        @Index(name = "idx_notification_email", columnList = "recipient_email")
+})
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+public class Notification extends BaseEntity {
+
+    /**
+     * ID único de la orden asociada a esta notificación.
+     */
+    @Column(name = "order_id", nullable = false)
+    private UUID orderId;
+
+    /**
+     * Dirección de correo electrónico del destinatario.
+     */
+    @Column(name = "recipient_email", nullable = false, length = 255)
+    private String recipientEmail;
+
+    /**
+     * Estado actual de la notificación (SENT, FAILED, PENDING).
+     */
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 50)
+    private NotificationStatus status;
+
+    /**
+     * Mensaje relacionado con el estado, como una descripción
+     * del resultado del envío o del error producido.
+     */
+    @Column(name = "message", columnDefinition = "TEXT")
+    private String message;
+
+}

--- a/src/main/java/com/infragest/infra_notifications_service/enums/NotificationStatus.java
+++ b/src/main/java/com/infragest/infra_notifications_service/enums/NotificationStatus.java
@@ -1,0 +1,14 @@
+package com.infragest.infra_notifications_service.enums;
+
+/**
+ * Enum que define los estados posibles de una notificación.
+ * Utilizado en la entidad {@link com.infragest.infra_notifications_service.entity.Notification}.
+ *
+ * @author
+ * @since 2026-01-27
+ */
+public enum NotificationStatus {
+    SENT, // Notificación enviada exitosamente.
+    FAILED, // Intento de notificación fallido.
+    PENDING // Notificación pendiente de envío.
+}

--- a/src/main/java/com/infragest/infra_notifications_service/repository/NotificationRepository.java
+++ b/src/main/java/com/infragest/infra_notifications_service/repository/NotificationRepository.java
@@ -1,0 +1,9 @@
+package com.infragest.infra_notifications_service.repository;
+
+import com.infragest.infra_notifications_service.entity.Notification;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface NotificationRepository extends JpaRepository<Notification, UUID> {
+}

--- a/src/main/java/com/infragest/infra_notifications_service/service/impl/NotificationServiceImpl.java
+++ b/src/main/java/com/infragest/infra_notifications_service/service/impl/NotificationServiceImpl.java
@@ -1,12 +1,17 @@
 package com.infragest.infra_notifications_service.service.impl;
 
+import com.infragest.infra_notifications_service.entity.Notification;
+import com.infragest.infra_notifications_service.enums.NotificationStatus;
 import com.infragest.infra_notifications_service.event.NotificationEvent;
 import com.infragest.infra_notifications_service.event.OrderEvent;
+import com.infragest.infra_notifications_service.repository.NotificationRepository;
 import com.infragest.infra_notifications_service.service.NotificationService;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.stereotype.Service;
+
+import java.util.UUID;
 
 /**
  * Implementación del servicio de notificaciones para manejar eventos relacionados con órdenes.
@@ -24,12 +29,18 @@ public class NotificationServiceImpl implements NotificationService {
     private final RabbitTemplate rabbitTemplate;
 
     /**
+     * NotificationRepository: repositorio de notification.
+     */
+    private final NotificationRepository notificationRepository;
+
+    /**
      * Constructor con los parametros de la clase.
      *
      * @param rabbitMQConfig RabbitTemplate configurado para la interacción con RabbitMQ.
      */
-    public NotificationServiceImpl(RabbitTemplate rabbitMQConfig) {
+    public NotificationServiceImpl(RabbitTemplate rabbitMQConfig, NotificationRepository notificationRepository) {
         this.rabbitTemplate = rabbitMQConfig;
+        this.notificationRepository = notificationRepository;
     }
 
     /**
@@ -41,33 +52,50 @@ public class NotificationServiceImpl implements NotificationService {
     @Override
     @RabbitListener(queues = "notifications.queue")
     public void processOrderCreatedEvent(OrderEvent orderEvent) {
-        log.info("Procesando evento: {}", orderEvent);
 
-        try {
-            sendNotification(orderEvent);
-        } catch (Exception ex) {
-            log.error("Error procesando la notificación para la orden ID: {}", orderEvent.getOrderId(), ex);
-            throw ex;
+        log.info("Procesando evento de orden ID: {}", orderEvent.getOrderId());
+
+        if (orderEvent.getRecipientEmails() == null || orderEvent.getRecipientEmails().isEmpty()) {
+            log.warn("No se encontraron destinatarios para la orden ID: {}", orderEvent.getOrderId());
+            saveNotification(orderEvent.getOrderId(), null, NotificationStatus.FAILED, "Sin destinatarios para la notificación.");
+            sendConfirmation(orderEvent, "FAILED");
+            return;
         }
+
+        // Enviar notificaciones a los destinatarios
+        orderEvent.getRecipientEmails().forEach(email -> {
+            try {
+                sendNotification(orderEvent, email);
+            } catch (Exception ex) {
+                log.error("Error al enviar notificación a: {} para la orden ID: {}", email, orderEvent.getOrderId(), ex);
+                saveNotification(orderEvent.getOrderId(), email, NotificationStatus.FAILED, ex.getMessage());
+            }
+        });
+
+        // Publicar confirmación general como éxito si al menos un correo se envió
+        sendConfirmation(orderEvent, "SUCCESS");
     }
 
     /**
-     * Envía una notificación basada en el evento recibido.
+     * Envía una notificación a un correo específico y registra el resultado.
      *
-     * @param orderEvent Evento que contiene los datos relevantes para la notificación.
+     * @param orderEvent Evento que contiene el ID de la orden y otros datos relevantes.
+     * @param recipientEmail Correo electrónico del destinatario.
      */
-    private void sendNotification(OrderEvent orderEvent) {
-        log.info("Enviando notificación para la orden ID: {}", orderEvent.getOrderId());
+    private void sendNotification(OrderEvent orderEvent, String recipientEmail) {
+        log.info("Enviando notificación a: {} para la orden ID: {}", recipientEmail, orderEvent.getOrderId());
 
+        // Simulación de envío real de correo (aquí podrías usar SendGrid o una API similar)
         try {
-            // Lógica real de envío
-            log.info("Notificación enviada para la orden ID: {}", orderEvent.getOrderId());
-            sendConfirmation(orderEvent, "SUCCESS");
+            // Simular lógica de envío de correo (esto sería la integración real con un cliente de correos)
+            log.info("Correo enviado satisfactoriamente a: {}", recipientEmail);
+            saveNotification(orderEvent.getOrderId(), recipientEmail, NotificationStatus.SENT, "Correo enviado exitosamente.");
         } catch (Exception ex) {
-            log.error("Fallo en el envío de la notificación para la orden ID: {}", orderEvent.getOrderId());
-            sendConfirmation(orderEvent, "FAILED");
+            log.error("Error enviando correo a: {}", recipientEmail, ex);
+            throw new RuntimeException("Fallo en notificación a " + recipientEmail, ex);
         }
     }
+
 
     /**
      * Publica una confirmación en RabbitMQ después de procesar un evento de notificación.
@@ -89,5 +117,26 @@ public class NotificationServiceImpl implements NotificationService {
     @Override
     public void processOrderUpdatedEvent(OrderEvent orderEvent) {
 
+    }
+
+    /**
+     * Guarda el resultado de una notificación en la base de datos.
+     *
+     * @param orderId ID de la orden asociada.
+     * @param recipientEmail Correo electrónico del destinatario.
+     * @param status Estado de la notificación (SENT, FAILED, PENDING).
+     * @param message Mensaje adicional relacionado con el envío.
+     */
+    public void saveNotification(UUID orderId, String recipientEmail, NotificationStatus status, String message) {
+        Notification notification = Notification.builder()
+                .orderId(orderId)
+                .recipientEmail(recipientEmail)
+                .status(status)
+                .message(message)
+                .build();
+
+        notificationRepository.save(notification);
+        log.info("Notificación registrada: Orden ID: {}, Email: {}, Estado: {}, Mensaje: {}",
+                orderId, recipientEmail, status, message);
     }
 }


### PR DESCRIPTION
# 🚀 Pull Request

## Descripción
- Se añade entidad `Notification` para rastrear el estado de las notificaciones enviadas por el sistema.
- Mapea la tabla `notifications` en la base de datos.
- Hereda de la clase base `BaseEntity` para incluir atributos comunes (`id`, `createdAt`, `updatedAt`, `version`).
- Contiene información sobre las notificaciones, como `orderId`, `recipientEmail`, `status` y `message`.
- Se añaden índices relevantes para optimizar consultas (`status`, `orderId`, y `recipientEmail`).
- Se agrega clase Enum NotificationStatus define los estados posibles de una notificación.
- Se agrega repositorio NotificationRepository permite manejar operaciones de persistencia y futuras consultas adicionales sobre la entidad `Notification`.
- Se agrega método saveNotification permite registrar notificaciones individuales en la base de datos, registrando su estado (`SENT`, `FAILED`, o `PENDING`) y un mensaje asociado.

## ¿Qué tipo de cambio es?
- [ ] Bugfix 🐞
- [x] Feature ✨
- [ ] Refactor 🔧
- [ ] Documentación 📚
- [ ] Otro

## ¿Cómo probar estos cambios?
- Llama al método `saveNotification` con valores de prueba.
- Verifica que las notificaciones se guarden correctamente en la base de datos.
- Confirma que los registros en la tabla `notifications` incluyen campos como `orderId`, `recipientEmail`, `status`, y `message`.


## Checklist
- [ ] El código compila y pasa los tests
- [ ] La documentación está actualizada (si aplica)
- [ ] No hay warnings nuevos
- [ ] Revisé el formato y convenciones de código

## Screenshots (si aplica)
<!-- Adjunta capturas si hay cambios visuales. -->

## Issue relacionada
<!-- Si hay issues asociadas, referencia: closes #123 -->

## Notas para el revisor
- La funcionalidad de envío de correos (**SendGrid**) aún no está implementada en este PR.
- Este PR sienta las bases para persistir los resultados de las notificaciones, que serán usadas en futuros procesos de auditoría y rediseño.
