### PR TITLE
feat(issue-8): Se normaliza mensajes de excepciones para las notificaciones

### DIFF
--- a/src/main/java/com/infragest/infra_notifications_service/service/impl/SendGridEmailServiceImpl.java
+++ b/src/main/java/com/infragest/infra_notifications_service/service/impl/SendGridEmailServiceImpl.java
@@ -2,6 +2,7 @@ package com.infragest.infra_notifications_service.service.impl;
 
 import com.infragest.infra_notifications_service.exception.SengridException;
 import com.infragest.infra_notifications_service.service.SendGridEmailService;
+import com.infragest.infra_notifications_service.util.MessageException;
 import com.sendgrid.Method;
 import com.sendgrid.Request;
 import com.sendgrid.Response;
@@ -36,18 +37,27 @@ public class SendGridEmailServiceImpl implements SendGridEmailService {
     @Override
     public void sendEmail(String recipientEmail, String subject, String content) {
         if (fromEmail == null || fromEmail.isBlank()) {
-            throw new SengridException("El remitente (fromEmail) no está configurado.", SengridException.Type.INVALID_REQUEST);
+            throw new SengridException(MessageException.SENDER_EMAIL_NOT_CONFIGURED, SengridException.Type.INVALID_REQUEST);
         }
 
-        Email from = new Email(fromEmail); // Configurar remitente
-        Email to = new Email(recipientEmail); // Configurar destinatario
-        Content emailContent = new Content("text/plain", content); // Contenido del correo
-        Mail mail = new Mail(from, subject, to, emailContent); // Crear el correo
+        // Configurar remitente
+        Email from = new Email(fromEmail);
 
-        SendGrid sg = new SendGrid(sendGridApiKey); // Iniciar la conexión con la API Key
+        // Configurar destinatario
+        Email to = new Email(recipientEmail);
+
+        // Contenido del correo
+        Content emailContent = new Content("text/plain", content);
+
+        // Crear el correo
+        Mail mail = new Mail(from, subject, to, emailContent);
+
+        // Iniciar la conexión con la API Key
+        SendGrid sg = new SendGrid(sendGridApiKey);
         Request request = new Request();
 
         try {
+
             // Configurar el request de envío
             request.setMethod(Method.POST);
             request.setEndpoint("mail/send");
@@ -60,12 +70,13 @@ public class SendGridEmailServiceImpl implements SendGridEmailService {
                 return;
             } else {
                 // Manejo de errores por parte de SendGrid
-                throw new SengridException("Error al enviar correo. Código de estado: " + response.getStatusCode()
-                        + ", Respuesta: " + response.getBody(), SengridException.Type.API_ERROR);
+                throw new SengridException(String.format(MessageException.SENDGRID_API_ERROR,
+                        response.getStatusCode(),
+                        response.getBody()), SengridException.Type.API_ERROR);
             }
         } catch (IOException ex) {
             // Manejo de errores relacionados con la conexión o la IO
-            throw new SengridException("Fallo al conectar con SendGrid. Detalle: " + ex.getMessage(), SengridException.Type.SERVICE_UNAVAILABLE);
+            throw new SengridException(String.format(MessageException.SENDGRID_CONNECTION_FAILURE, ex.getMessage()), SengridException.Type.SERVICE_UNAVAILABLE);
         }
     }
 }

--- a/src/main/java/com/infragest/infra_notifications_service/util/MessageException.java
+++ b/src/main/java/com/infragest/infra_notifications_service/util/MessageException.java
@@ -1,0 +1,12 @@
+package com.infragest.infra_notifications_service.util;
+
+public abstract class MessageException {
+
+    private MessageException() {}
+
+    // Sengrid
+    public static final String SENDER_EMAIL_NOT_CONFIGURED = "The sender email (fromEmail) is not configured.";
+    public static final String SENDGRID_API_ERROR = "Failed to send email. Status code: %s, Response: %s";
+    public static final String SENDGRID_CONNECTION_FAILURE = "Failed to connect to SendGrid. Details: %s";
+
+}


### PR DESCRIPTION
# 🚀 Pull Request

## Descripción

- Se centralizan los mensajes de error y excepciones en la clase `MessageException`, asegurando consistencia en el manejo de errores.
- Se actualizan los mensajes de excepción en el servicio `SendGridEmailServiceImpl` para usar los mensajes normalizados y traducidos al inglés.


## ¿Qué tipo de cambio es?
- [ ] Bugfix 🐞
- [x] Feature ✨
- [x] Refactor 🔧
- [x] Documentación 📚
- [ ] Otro

## ¿Cómo probar estos cambios?

Probar  enviando un correo cuando la variable `fromEmail` no está configurada y verifica que se lanza una excepción con el mensaje: 

## Checklist
- [x] El código compila y pasa los tests
- [x] La documentación está actualizada (si aplica)
- [x] No hay warnings nuevos
- [x] Revisé el formato y convenciones de código

## Screenshots (si aplica)
Nn

## Issue relacionada
Nn

## Notas para el revisor
Nn
